### PR TITLE
Add some comments about running Keysight I/O in the container 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,9 @@ RUN apt-get install lsb-core -y
 # this command can fail with the error
 # "This device is not connected to the network"
 # if the container cannot get out to the internet
-RUN ./keysightiolib.run --mode unattended
+# It *might not* hang if you add the --enable-debugger flag?
+RUN ./keysightiolib.run --mode unattended --enable-debugger
+
+# add a soft link to the Keysight VISA library in the OpenTAP directory
+RUN ln -s /opt/keysight/iolibs/libktvisa32.so /opt/tap/libvisa.so
 

--- a/build.sh
+++ b/build.sh
@@ -6,4 +6,4 @@ docker container rm -f ot > /dev/null 2>&1
 docker image rm -f ot > /dev/null 2>&1
 
 # create the image anew, give it a name of "ot"
-docker build -t ot .
+docker build --network host -t ot . 

--- a/run.sh
+++ b/run.sh
@@ -9,3 +9,9 @@ docker rm -f ot > /dev/null 2>&1
 # run the "ot" image and give resulting container
 # a name of "ot"
 docker run -it --network host --name ot ot
+
+# once the container is running, you need to run the Keysight Instrument Discovery Service in the background
+# /opt/keysight/iolibs/ds/start-discoveryservice.sh &
+
+# to test that VISA is working you can run the vifind utility (it won't hang if the Discovery Service is running)
+# /opt/keysight/iolibs/utils/vifind 


### PR DESCRIPTION
…with OpenTAP, and add a simple installer flag that *might* keep the Keysight I/O installer from hanging during install.

Works with TUI and an instrument using SCPI Sockets (port 5025).

![image](https://user-images.githubusercontent.com/69871845/142361093-afde53fa-221b-436f-a6b4-035dabe9a60c.png)